### PR TITLE
fix: CIの改行コード不一致で落ちる問題を根本修正

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## 概要\n- CI失敗の根因だった改行コード不一致（LFポリシーと実ファイルの乖離）に対して、再発防止設定を追加\n\n## 変更内容\n- .gitattributes を追加\n  - * text=auto eol=lf を設定し、OS差異によるCRLF混入を防止\n\n## 期待効果\n- Windows環境で編集されたファイルが混在しても、Git管理下ではLFに正規化され、Biomeのフォーマット/lintが安定\n\n## 検証\n- pnpm lint\n- pnpm typecheck\n- pnpm vitest run --coverage\n- cd src-tauri && cargo test\n\n## 備考\n- ルール緩和や無視設定による回避は行っていません。